### PR TITLE
Fixes for Date processing and and last_active property.

### DIFF
--- a/cleanup_atlassian.py
+++ b/cleanup_atlassian.py
@@ -156,16 +156,8 @@ def cleanup(
                 product_last_access_dates = []
                 for product in user["product_access"]:
                     if "last_active" in product:
-                        # Having to strip out the "microseconds" here since strptime supports
-                        # 6 DPs and the Atlassian API has started returning 9.
-                        # Nanosecond accuracy not required here!
-                        # Recent example: '2023-08-01T15:19:32.354230769Z'
-                        # Throws a ValueError: time data does not match format '%Y-%m-%dT%H:%M:%S.%fZ'
                         product_last_access_dates.append(
-                            datetime.strptime(
-                                product["last_active"].split(".")[0]+"Z",
-                                "%Y-%m-%dT%H:%M:%SZ"
-                            )
+                            parse_dt(product["last_active"])
                             .replace(tzinfo=UTC)
                             .isoformat()
                         )

--- a/cleanup_atlassian.py
+++ b/cleanup_atlassian.py
@@ -192,7 +192,7 @@ def cleanup(
             if ENABLE_DEACTIVATIONS:
                 logger.info(
                     "Disabling user '%s' (index %s) because their last access was: %s",
-                    user["name"],
+                    user.get("name","none"),
                     index,
                     user.get("last_active","'none'"),
                 )
@@ -201,7 +201,7 @@ def cleanup(
             else:
                 logger.info(
                     "User deactivation not enabled. But user '%s' (index %s) would be deactivated because their last access was: %s",
-                    user["name"],
+                    user.get("name","none"),
                     index,
                     user.get("last_active","'none'"),
                 )

--- a/cleanup_atlassian.py
+++ b/cleanup_atlassian.py
@@ -194,7 +194,7 @@ def cleanup(
                     "Disabling user '%s' (index %s) because their last access was: %s",
                     user["name"],
                     index,
-                    user["last_active"],
+                    user.get("last_active","'none'"),
                 )
                 resp = atlassian_client.disable_user(user["account_id"], body=msg)
                 logger.info("Response: %s", resp)
@@ -203,7 +203,7 @@ def cleanup(
                     "User deactivation not enabled. But user '%s' (index %s) would be deactivated because their last access was: %s",
                     user["name"],
                     index,
-                    user["last_active"],
+                    user.get("last_active","'none'"),
                 )
     else:
         logger.error('Error: Atlassian organisation "%s" not found', organisation_name)

--- a/cleanup_atlassian.py
+++ b/cleanup_atlassian.py
@@ -184,19 +184,19 @@ def cleanup(
             if ENABLE_DEACTIVATIONS:
                 logger.info(
                     "Disabling user '%s' (index %s) because their last access was: %s",
-                    user.get("name","none"),
+                    user.get("name"),
                     index,
-                    user.get("last_active","'none'"),
+                    user.get("last_active"),
                 )
                 resp = atlassian_client.disable_user(user["account_id"], body=msg)
                 logger.info("Response: %s", resp)
             else:
                 logger.info(
                     "User deactivation not enabled. But user '%s' (index %s) with email '%s' would be deactivated because their last access was: %s",
-                    user.get("name","none"),
+                    user.get("name"),
                     index,
-                    user.get("email","none"),
-                    user.get("last_active","'none'"),
+                    user.get("email"),
+                    user.get("last_active"),
                 )
     else:
         logger.error('Error: Atlassian organisation "%s" not found', organisation_name)

--- a/cleanup_atlassian.py
+++ b/cleanup_atlassian.py
@@ -156,9 +156,15 @@ def cleanup(
                 product_last_access_dates = []
                 for product in user["product_access"]:
                     if "last_active" in product:
+                        # Having to strip out the "microseconds" here since strptime supports
+                        # 6 DPs and the Atlassian API has started returning 9.
+                        # Nanosecond accuracy not required here!
+                        # Recent example: '2023-08-01T15:19:32.354230769Z'
+                        # Throws a ValueError: time data does not match format '%Y-%m-%dT%H:%M:%S.%fZ'
                         product_last_access_dates.append(
                             datetime.strptime(
-                                product["last_active"], "%Y-%m-%dT%H:%M:%S.%fZ"
+                                product["last_active"].split(".")[0]+"Z",
+                                "%Y-%m-%dT%H:%M:%SZ"
                             )
                             .replace(tzinfo=UTC)
                             .isoformat()

--- a/cleanup_atlassian.py
+++ b/cleanup_atlassian.py
@@ -200,9 +200,10 @@ def cleanup(
                 logger.info("Response: %s", resp)
             else:
                 logger.info(
-                    "User deactivation not enabled. But user '%s' (index %s) would be deactivated because their last access was: %s",
+                    "User deactivation not enabled. But user '%s' (index %s) with email '%s' would be deactivated because their last access was: %s",
                     user.get("name","none"),
                     index,
+                    user.get("email","none"),
                     user.get("last_active","'none'"),
                 )
     else:


### PR DESCRIPTION
Makes the following changes:
- Replaces `datetime.strptime` with `parse` to process the nanoseconds from the date returned from the Atlassian API - since it now returns seconds to 9 DPs (not 6) which causes a ValueError with `strptime`
- Update to catch records where `last_active` property is not set. I've noticed a few (folks never logged in)
- Add the account e-mail to the log (in case of duplicate accounts over multiple domains).

---

**ValueError:**
Recent example: '2023-08-01T15:19:32.354230769Z'
Throws `ValueError: data does not match format '%Y-%m-%dT%H:%M:%S.%fZ'`
But '2023-08-01T15:19:32.354230Z' works fine.